### PR TITLE
Add local plugin UI checks

### DIFF
--- a/docs/local-plugin-testing.md
+++ b/docs/local-plugin-testing.md
@@ -15,7 +15,8 @@
 ```bash
 python3 scripts/sync_packaged_plugins.py
 python3 scripts/run_local_plugin_smoke_checks.py
-python3 scripts/run_local_plugin_load_assistant.py --run-smoke
+python3 scripts/run_local_plugin_ui_checks.py --write-report
+python3 scripts/run_local_plugin_load_assistant.py --run-smoke --run-ui-checks
 ```
 
 그 다음:
@@ -29,6 +30,7 @@ python3 scripts/run_local_plugin_load_assistant.py --run-smoke
 - `.agents/plugins/marketplace.json`이 현재 packaged plugins와 맞는지
 - `plugins/*/.codex-plugin/plugin.json` 경로 참조가 깨지지 않았는지
 - packaged assets가 모두 존재하는지
+- `reports/local-plugin-ui-report-*.md`에 UI 기대 상태가 정리됐는지
 - Codex UI에서 실제로 plugin이 로드되는지
 
 ### 빠른 확인용 starter prompts
@@ -73,6 +75,7 @@ python3 scripts/sync_packaged_plugins.py
 
 ```bash
 python3 scripts/run_local_plugin_smoke_checks.py
+python3 scripts/run_local_plugin_ui_checks.py --write-report
 ```
 
 필요하면 개별 검증도 돌립니다.
@@ -92,14 +95,30 @@ python3 .agents/skills/codex-skill-audit/scripts/audit_codex_skill_repo.py .
 ### Step 3. 로컬 로딩 체크리스트 생성
 
 ```bash
-python3 scripts/run_local_plugin_load_assistant.py --run-smoke
+python3 scripts/run_local_plugin_load_assistant.py --run-smoke --run-ui-checks
 ```
 
 이 스크립트는:
 
 - 정적 smoke check를 한 번 더 돌리고
+- UI verification report도 생성하고
 - `reports/local-plugin-load-checklist-*.md`를 생성해
 - 실제 UI 확인 순서를 정리해 줍니다.
+
+### Step 3a. UI verification report만 따로 생성
+
+```bash
+python3 scripts/run_local_plugin_ui_checks.py --write-report
+```
+
+이 스크립트는 plugin별로 아래 기대 상태를 정리합니다.
+
+- display name
+- category
+- icon / logo / screenshots 경로
+- screenshot 개수
+- starter prompt 개수와 예시 prompt
+- 수동 UI 체크리스트
 
 ### Step 4. Codex UI 로딩 확인
 
@@ -171,7 +190,8 @@ python3 scripts/sync_packaged_plugins.py
 ```bash
 python3 scripts/sync_packaged_plugins.py
 python3 scripts/run_local_plugin_smoke_checks.py
-python3 scripts/run_local_plugin_load_assistant.py --run-smoke
+python3 scripts/run_local_plugin_ui_checks.py --write-report
+python3 scripts/run_local_plugin_load_assistant.py --run-smoke --run-ui-checks
 ```
 
 그 다음 Codex를 재시작하고, generated checklist를 따라 UI에서 수동 확인합니다.
@@ -182,6 +202,7 @@ python3 scripts/run_local_plugin_load_assistant.py --run-smoke
 
 - `scripts/sync_packaged_plugins.py`
 - `scripts/run_local_plugin_smoke_checks.py`
+- `scripts/run_local_plugin_ui_checks.py`
 - `scripts/run_local_plugin_load_assistant.py`
 - `plugins/README.md`
 - `.agents/plugins/marketplace.json`

--- a/scripts/run_local_plugin_load_assistant.py
+++ b/scripts/run_local_plugin_load_assistant.py
@@ -15,12 +15,18 @@ def main() -> int:
     parser = argparse.ArgumentParser(description='Prepare a local Codex plugin load checklist and optional docs open step.')
     parser.add_argument('--open-docs', action='store_true', help='Open the testing doc and generated checklist on macOS')
     parser.add_argument('--run-smoke', action='store_true', help='Run static smoke checks before generating the checklist')
+    parser.add_argument('--run-ui-checks', action='store_true', help='Run semi-automated UI verification report before generating the checklist')
     args = parser.parse_args()
 
     if args.run_smoke:
         result = subprocess.run(['python3', 'scripts/run_local_plugin_smoke_checks.py', '--skip-regenerate'], cwd=ROOT)
         if result.returncode != 0:
             print('정적 스모크 체크가 실패했습니다. 체크리스트 생성은 계속하지만 먼저 실패 원인을 확인하세요.')
+
+    if args.run_ui_checks or args.run_smoke:
+        result = subprocess.run(['python3', 'scripts/run_local_plugin_ui_checks.py', '--write-report'], cwd=ROOT)
+        if result.returncode != 0:
+            print('UI verification report 생성 중 경고가 있었습니다. generated report를 함께 확인하세요.')
 
     marketplace = json.loads((ROOT / '.agents' / 'plugins' / 'marketplace.json').read_text())
     plugins = marketplace.get('plugins', [])
@@ -39,8 +45,9 @@ def main() -> int:
         '',
         '1. `python3 scripts/sync_packaged_plugins.py` 실행',
         '2. `python3 scripts/run_local_plugin_smoke_checks.py` 실행',
-        '3. 필요하면 `python3 scripts/run_local_plugin_load_assistant.py --run-smoke`로 체크리스트를 다시 생성',
-        '4. Codex를 현재 저장소 루트에서 재시작',
+        '3. `python3 scripts/run_local_plugin_ui_checks.py --write-report` 실행',
+        '4. 필요하면 `python3 scripts/run_local_plugin_load_assistant.py --run-smoke --run-ui-checks`로 체크리스트를 다시 생성',
+        '5. Codex를 현재 저장소 루트에서 재시작',
         '',
         '## Plugins to verify',
         '',
@@ -69,6 +76,7 @@ def main() -> int:
         '',
         '- 빠른 확인 흐름은 docs/local-plugin-testing.md의 `1. 빠른 확인` 절차를 따른다.',
         '- 더 자세한 유지보수 순서는 docs/local-plugin-testing.md의 `2. 유지보수 전체 절차`를 따른다.',
+        '- UI 반자동 검증 결과는 `reports/local-plugin-ui-report-*.md` / `.json`으로 저장된다.',
         '- 현재 packaged screenshot은 representative preview이며, live Codex UI capture는 아닙니다.',
         '- 실제 live capture로 교체하려면 plugin 로딩 후 수동 캡처 또는 별도 UI 자동화가 필요합니다.',
         '',

--- a/scripts/run_local_plugin_smoke_checks.py
+++ b/scripts/run_local_plugin_smoke_checks.py
@@ -107,6 +107,9 @@ def main() -> int:
     overall_ok &= check_assets()
     overall_ok &= check_manifest_paths()
 
+    ok, _ = run(['python3', 'scripts/run_local_plugin_ui_checks.py', '--strict'], 'UI verification report')
+    overall_ok &= ok
+
     ok, _ = run(['python3', '.agents/skills/plugin-doctor/scripts/audit_codex_plugin_repo.py', '.'], 'plugin-doctor 감사')
     overall_ok &= ok
     ok, _ = run(['python3', '.agents/skills/codex-skill-audit/scripts/audit_codex_skill_repo.py', '.'], 'skill audit')

--- a/scripts/run_local_plugin_ui_checks.py
+++ b/scripts/run_local_plugin_ui_checks.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REPORTS = ROOT / 'reports'
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def build_plugin_rows(selected: set[str] | None):
+    marketplace = load_json(ROOT / '.agents' / 'plugins' / 'marketplace.json')
+    plugins = marketplace.get('plugins', [])
+    rows = []
+    findings = []
+    for entry in plugins:
+        name = entry['name']
+        if selected and name not in selected:
+            continue
+        plugin_root = ROOT / 'plugins' / name
+        manifest_path = plugin_root / '.codex-plugin' / 'plugin.json'
+        manifest = load_json(manifest_path)
+        interface = manifest.get('interface', {})
+
+        screenshots = interface.get('screenshots', []) or []
+        prompts = interface.get('defaultPrompt', []) or []
+        composer_icon = interface.get('composerIcon')
+        logo = interface.get('logo')
+        display_name = interface.get('displayName', '')
+        short_description = interface.get('shortDescription', '')
+        category = interface.get('category', entry.get('category', ''))
+
+        if not display_name:
+            findings.append((name, 'displayName missing in plugin interface'))
+        if not short_description:
+            findings.append((name, 'shortDescription missing in plugin interface'))
+        if not category:
+            findings.append((name, 'category missing in plugin interface'))
+        if not isinstance(prompts, list) or not prompts:
+            findings.append((name, 'defaultPrompt list missing or empty'))
+        if not isinstance(screenshots, list) or not screenshots:
+            findings.append((name, 'screenshots list missing or empty'))
+
+        refs = []
+        for label, rel in [('composerIcon', composer_icon), ('logo', logo)]:
+            if isinstance(rel, str):
+                refs.append((label, rel))
+            else:
+                findings.append((name, f'{label} missing or invalid'))
+        for idx, rel in enumerate(screenshots, start=1):
+            refs.append((f'screenshots[{idx}]', rel))
+
+        broken_refs = []
+        for label, rel in refs:
+            if not isinstance(rel, str) or not rel.startswith('./'):
+                broken_refs.append(f'{label}:{rel}')
+                continue
+            if not (plugin_root / rel[2:]).exists():
+                broken_refs.append(f'{label}:{rel}')
+        if broken_refs:
+            findings.append((name, 'broken UI asset refs -> ' + ', '.join(broken_refs)))
+
+        rows.append({
+            'name': name,
+            'display_name': display_name,
+            'category': category,
+            'short_description': short_description,
+            'source_path': f'plugins/{name}',
+            'screenshot_count': len(screenshots),
+            'screenshots': screenshots,
+            'prompt_count': len(prompts) if isinstance(prompts, list) else 0,
+            'example_prompt': prompts[0] if isinstance(prompts, list) and prompts else '',
+            'composer_icon': composer_icon,
+            'logo': logo,
+            'manual_checks': [
+                'catalog에 보이는지 확인',
+                'detail panel에서 아이콘/로고/스크린샷이 보이는지 확인',
+                'starter prompt 1개 실행',
+            ],
+        })
+    return rows, findings
+
+
+def render_markdown(rows, findings):
+    lines = [
+        '# Local Plugin UI Verification Report',
+        '',
+        f'- Generated: {datetime.now().isoformat(timespec="seconds")}',
+        f'- Root: `{ROOT}`',
+        f'- Plugins covered: `{len(rows)}`',
+        f'- Findings: `{len(findings)}`',
+        '',
+        '## Summary',
+        '- 이 리포트는 로컬 plugin UI에서 확인해야 할 표시명, 카테고리, 아이콘/로고/스크린샷, starter prompt를 구조화합니다.',
+        '',
+        '## Findings',
+    ]
+    if not findings:
+        lines.append('- None')
+    else:
+        for plugin_name, message in findings:
+            lines.append(f'- [warning] `{plugin_name}` — {message}')
+
+    lines.extend(['', '## Plugins to verify'])
+    for row in rows:
+        lines.append(f'### {row["name"]}')
+        lines.append(f'- Display: `{row["display_name"]}`')
+        lines.append(f'- Category: `{row["category"]}`')
+        lines.append(f'- Source: `{row["source_path"]}`')
+        lines.append(f'- Short description: {row["short_description"]}')
+        lines.append(f'- UI assets: composerIcon=`{row["composer_icon"]}`, logo=`{row["logo"]}`')
+        lines.append(f'- Screenshots: `{row["screenshot_count"]}`')
+        for shot in row['screenshots']:
+            lines.append(f'  - `{shot}`')
+        lines.append(f'- Starter prompts: `{row["prompt_count"]}`')
+        if row['example_prompt']:
+            lines.append(f'  - Example prompt: `{row["example_prompt"]}`')
+        lines.append('- Manual checks:')
+        for item in row['manual_checks']:
+            lines.append(f'  - [ ] {item}')
+        lines.append('')
+
+    lines.extend([
+        '## Next manual steps',
+        '1. `python3 scripts/run_local_plugin_smoke_checks.py --skip-regenerate` 실행',
+        '2. Codex를 현재 저장소 루트에서 재시작',
+        '3. local catalog에서 각 plugin card와 detail panel을 확인',
+        '4. plugin별 starter prompt 1개 이상 실행',
+        '',
+        '## Machine summary',
+        '```json',
+        json.dumps({
+            'report_type': 'local-plugin-ui-check',
+            'schema_version': 1,
+            'root': str(ROOT),
+            'plugins_count': len(rows),
+            'findings_count': len(findings),
+            'findings': [{'plugin': plugin, 'message': message} for plugin, message in findings],
+            'plugins': rows,
+        }, ensure_ascii=False, indent=2),
+        '```',
+        '',
+    ])
+    return '\n'.join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Build a semi-automated local plugin UI verification report.')
+    parser.add_argument('--plugin', action='append', help='특정 plugin만 포함')
+    parser.add_argument('--strict', action='store_true', help='finding이 있으면 non-zero 종료')
+    parser.add_argument('--write-report', action='store_true', help='reports/ 아래에 markdown/json artifact 저장')
+    parser.add_argument('--json-out', help='JSON summary 저장 경로')
+    parser.add_argument('--markdown-out', help='Markdown report 저장 경로')
+    args = parser.parse_args()
+
+    selected = set(args.plugin) if args.plugin else None
+    rows, findings = build_plugin_rows(selected)
+    markdown = render_markdown(rows, findings)
+    print(markdown, end='')
+
+    payload = {
+        'report_type': 'local-plugin-ui-check',
+        'schema_version': 1,
+        'root': str(ROOT),
+        'plugins_count': len(rows),
+        'findings_count': len(findings),
+        'findings': [{'plugin': plugin, 'message': message} for plugin, message in findings],
+        'plugins': rows,
+    }
+
+    if args.write_report:
+        REPORTS.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime('%Y-%m-%d-%H%M%S')
+        md_path = REPORTS / f'local-plugin-ui-report-{ts}.md'
+        json_path = REPORTS / f'local-plugin-ui-report-{ts}.json'
+        md_path.write_text(markdown, encoding='utf-8')
+        json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+        print(f'\nreport markdown: {md_path}')
+        print(f'report json: {json_path}')
+
+    if args.markdown_out:
+        out = Path(args.markdown_out).expanduser().resolve()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(markdown, encoding='utf-8')
+    if args.json_out:
+        out = Path(args.json_out).expanduser().resolve()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+
+    if args.strict and findings:
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/run_local_plugin_ui_checks.py` to generate a semi-automated UI verification report for packaged plugins
- wire the new UI report into `run_local_plugin_smoke_checks.py` and `run_local_plugin_load_assistant.py`
- update `docs/local-plugin-testing.md` so the quick/full flows include the UI verification report alongside smoke checks and checklist generation

## Validation
- `python3 -m py_compile scripts/run_local_plugin_ui_checks.py scripts/run_local_plugin_load_assistant.py scripts/run_local_plugin_smoke_checks.py`
- `python3 scripts/run_local_plugin_ui_checks.py --strict`
- `python3 scripts/run_local_plugin_load_assistant.py --run-ui-checks`
- `python3 scripts/run_local_plugin_smoke_checks.py --skip-regenerate`
- `python3 .agents/skills/codex-skill-audit/scripts/audit_codex_skill_repo.py .`

## Notes
- this is semi-automation: the script structures expected catalog/detail-panel state and starter prompts, but the actual Codex UI still needs a human to confirm visibility and execution
- generated UI reports continue to live under `reports/` and remain untracked
