### PR TITLE
Prepare v0.4.0 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # CHANGELOG
 
+## v0.4.0 — 2026-03-29
+
+관련 문서:
+
+- release notes: `docs/release-notes-v0.4.0.md`
+- announcement draft: `docs/release-announcement-v0.4.0.md`
+- roadmap: `docs/roadmap-v0.4.0.md`
+- release workflow: `docs/release-workflow.md`
+
+### 핵심 변경
+
+- release helper / install / goal-research-loop 회귀 검증을 CI에 연결해 release·install·runner 레이어의 자동 기준선을 확보했습니다.
+- packaged plugin parity를 single-skill에서 multi-skill, README, optional assets까지 확장했습니다.
+- evaluator-native skill 출력 계약을 공통 contract + machine summary schema 기반으로 정리했습니다.
+- `agent-context-verify`, `apple-review`, `agent-context-audit`에 deterministic formatter/script 흐름을 추가했습니다.
+- `goal-research-loop`에 `reconcile`, `resume`, runtime status를 도입하고 regression suite로 보강했습니다.
+- local plugin testing 문서를 quick path / maintenance path로 정리하고, UI verification report 흐름을 추가했습니다.
+
+### 세부 변경
+
+#### release / install / regression automation
+
+- `scripts/release_helper.py`
+- `scripts/run_release_smoke_checks.py`
+- `scripts/run_global_install_smoke_checks.py`
+- `scripts/run_goal_research_loop_regression.py`
+- `.github/workflows/release-smoke.yml`
+- `.github/workflows/install-smoke.yml`
+- `.github/workflows/goal-research-loop-smoke.yml`
+
+#### packaged plugin parity
+
+- `scripts/packaged_plugin_parity.py`
+- `plugin-doctor` drift 검사 확장
+- multi-skill plugin parity 규칙 반영
+  - `agent-context`
+  - `apple-craft`
+- packaged README / optional assets / screenshots parity 반영
+
+#### evaluator output standardization
+
+- `docs/evaluator-output-contract.md`
+- `codex-skill-audit` schema + `--json-out`
+- `plugin-doctor` schema + `--json-out`
+- `agent-context-verify` deterministic script + schema
+- `apple-review` deterministic formatter + schema
+- `agent-context-audit` deterministic formatter + schema
+- grouped summary / recommended fixes 포맷 보강
+
+#### goal-research-loop runner hardening
+
+- `reconcile`
+- `resume`
+- `runtime/status.json`
+- orphan round artifact 복구
+- pending round 보호
+- prompt profile / timeout / resume regression 검증
+
+#### local plugin testing
+
+- `docs/local-plugin-testing.md`
+- `scripts/run_local_plugin_load_assistant.py`
+- `scripts/run_local_plugin_ui_checks.py`
+
+### 검증에 사용한 명령
+
+```bash
+python3 scripts/run_release_smoke_checks.py --skip-gh-auth
+python3 scripts/run_global_install_smoke_checks.py
+python3 scripts/run_goal_research_loop_regression.py
+python3 scripts/run_local_plugin_smoke_checks.py --skip-regenerate
+python3 scripts/run_local_plugin_ui_checks.py --strict
+python3 .agents/skills/codex-skill-audit/scripts/audit_codex_skill_repo.py .
+python3 .agents/skills/plugin-doctor/scripts/audit_codex_plugin_repo.py .
+```
+
 이 문서는 이 저장소의 사용자 관점 변화와 릴리스 포인트를 기록합니다.
 
 ## v0.3.0 — 2026-03-29

--- a/docs/release-announcement-v0.4.0.md
+++ b/docs/release-announcement-v0.4.0.md
@@ -1,0 +1,44 @@
+# v0.4.0 발표문 초안
+
+`codex-skills-project` **v0.4.0**은 저장소의 핵심 운영 흐름을
+**더 자동화되고, 더 재현 가능하며, 더 기계적으로 검증 가능한 상태**로 끌어올리는 릴리스입니다.
+
+## 무엇이 달라졌나
+
+- release / install / goal-research-loop regression이 CI에서 자동 검증됩니다.
+- packaged plugin parity가 multi-skill / README / optional asset 수준까지 확장되었습니다.
+- evaluator-native skill 출력이 공통 contract와 machine summary schema 기반으로 정리되었습니다.
+- `goal-research-loop`는 `reconcile`, `resume`, runtime status를 갖춘 더 안정적인 runner가 되었습니다.
+- local plugin testing은 quick path / maintenance path / UI verification report 흐름으로 정리되었습니다.
+
+## 왜 중요한가
+
+이번 릴리스로 이 저장소는 단순히 skill을 모아 두는 공간이 아니라,
+
+- release가 깨지지 않는지,
+- install이 regress되지 않는지,
+- packaged/source가 drift하지 않는지,
+- evaluator 결과가 구조화되는지,
+- 장기 research loop가 안전하게 이어지는지
+
+를 모두 **반복 가능한 검사 레일 위**에서 운영할 수 있게 됩니다.
+
+## 포함된 핵심 변화
+
+- release helper smoke / install smoke / goal-research-loop smoke CI
+- packaged plugin multi-skill parity
+- evaluator output contract + formatter/schema
+- goal-research-loop resume/reconcile/runtime status
+- local plugin UI verification report
+
+## 검증
+
+```bash
+python3 scripts/run_release_smoke_checks.py --skip-gh-auth
+python3 scripts/run_global_install_smoke_checks.py
+python3 scripts/run_goal_research_loop_regression.py
+python3 scripts/run_local_plugin_smoke_checks.py --skip-regenerate
+python3 scripts/run_local_plugin_ui_checks.py --strict
+python3 .agents/skills/codex-skill-audit/scripts/audit_codex_skill_repo.py .
+python3 .agents/skills/plugin-doctor/scripts/audit_codex_plugin_repo.py .
+```

--- a/docs/release-notes-v0.4.0.md
+++ b/docs/release-notes-v0.4.0.md
@@ -1,0 +1,43 @@
+## v0.4.0
+
+이번 릴리스는 `v0.3.0` 이후 진행된 **회귀 검증 자동화**, **packaged plugin parity 확장**, **evaluator 출력 표준화**, **goal-research-loop 안정화**, **local plugin UI verification 흐름 추가**를 한 번에 묶습니다.
+
+### Highlights
+
+- Added regression automation for release / install / goal-research-loop
+  - `scripts/run_release_smoke_checks.py`
+  - `scripts/run_global_install_smoke_checks.py`
+  - `scripts/run_goal_research_loop_regression.py`
+- Expanded packaged plugin parity
+  - single-skill → multi-skill
+  - README / optional assets / screenshots parity
+- Standardized evaluator-native outputs
+  - shared evaluator output contract
+  - machine summary schemas / `--json-out`
+  - deterministic formatter/scripts for key evaluator skills
+- Hardened `goal-research-loop`
+  - `reconcile`
+  - `resume`
+  - runtime status and regression checks
+- Added semi-automated local plugin UI verification
+  - `scripts/run_local_plugin_ui_checks.py`
+
+### User-visible improvements
+
+- plugin / install / release regressions가 CI에서 더 빨리 드러납니다.
+- packaged plugin metadata와 source skill metadata가 더 일관되게 유지됩니다.
+- evaluator-native skill 결과를 사람과 자동화가 함께 읽기 쉬워졌습니다.
+- `goal-research-loop` interrupted run을 더 안전하게 이어받을 수 있습니다.
+- local plugin catalog/detail panel 점검이 report 기반으로 더 구조화됩니다.
+
+### Recommended validation
+
+```bash
+python3 scripts/run_release_smoke_checks.py --skip-gh-auth
+python3 scripts/run_global_install_smoke_checks.py
+python3 scripts/run_goal_research_loop_regression.py
+python3 scripts/run_local_plugin_smoke_checks.py --skip-regenerate
+python3 scripts/run_local_plugin_ui_checks.py --strict
+python3 .agents/skills/codex-skill-audit/scripts/audit_codex_skill_repo.py .
+python3 .agents/skills/plugin-doctor/scripts/audit_codex_plugin_repo.py .
+```


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md` entry for `v0.4.0`
- add `docs/release-notes-v0.4.0.md`
- add `docs/release-announcement-v0.4.0.md`

## Validation
- `python3 scripts/release_helper.py check --version v0.4.0`
- `python3 scripts/release_helper.py plan --version v0.4.0`
- `python3 .agents/skills/codex-skill-audit/scripts/audit_codex_skill_repo.py .`
- `python3 .agents/skills/plugin-doctor/scripts/audit_codex_plugin_repo.py .`

## Notes
- `v0.3.0` is already the current Latest GitHub release
- this PR prepares the required docs-first release artifacts only; it does not create the `v0.4.0` tag or release yet
- once merged, the next release command remains draft-first:
  - `python3 scripts/release_helper.py publish --version v0.4.0`
